### PR TITLE
Add explanation and example for included DateTime scalar type

### DIFF
--- a/website/versioned_docs/version-2.0/schema-scalars.md
+++ b/website/versioned_docs/version-2.0/schema-scalars.md
@@ -1,0 +1,28 @@
+---
+id: version-2.0-schema-scalars
+title: Scalar types
+original_id: schema-scalars
+---
+
+As we learned earlier, we can use Scalar types to serialize, deserialize and validate values. 
+To use these scalar types we have to define them in our schema.<br /><br />
+
+## DateTime
+
+If you are using Eloquent, it is very likely that your `created_at` and `updated_at` fields are returned as a [Carbon](https://carbon.nesbot.com/) instance.
+A DateTime scalar type can be used to return these fields correcly in your API. You can use it inside your schema like this:
+
+```graphql
+scalar DateTime @scalar(class: "Nuwave\\Lighthouse\\Schema\\Types\\Scalars\\DateTime")
+
+type User {
+  id: ID!
+  name: String!
+  email: String!
+  created_at: DateTime!
+  updated_at: DateTime
+}
+```
+
+The DateTime scalar deserializes the Carbon instance into a `Y-m-d H:i:s` format when the field is selected by the GraphQL consumer. 
+When you are using mutations to persist data to your database, it also expects this format. 

--- a/website/versioned_docs/version-2.0/schema-schema.md
+++ b/website/versioned_docs/version-2.0/schema-schema.md
@@ -52,7 +52,7 @@ Ligthouse includes a DateTime scalar type. This scalar type can be used to handl
 You can use it inside your schema like this:
 
 ```graphql
-scalar DateTime @scalar(class: "App\\GraphQL\\Scalars\\DateTime")
+scalar DateTime @scalar(class: "Nuwave\\Lighthouse\\Schema\\Types\\Scalars\\DateTime")
 
 type User {
   id: ID!

--- a/website/versioned_docs/version-2.0/schema-schema.md
+++ b/website/versioned_docs/version-2.0/schema-schema.md
@@ -47,21 +47,6 @@ type Mutation {
 ## Scalar Types
 
 Scalar types are custom types that require a `directive` (which we'll learn about later) to serialize, deserialize and validate values.
-<br><br>
-Ligthouse includes a DateTime scalar type. This scalar type can be used to handle Carbon DateTime fields. 
-You can use it inside your schema like this:
-
-```graphql
-scalar DateTime @scalar(class: "Nuwave\\Lighthouse\\Schema\\Types\\Scalars\\DateTime")
-
-type User {
-  id: ID!
-  name: String!
-  email: String!
-  created_at: DateTime!
-  updated_at: DateTime
-}
-```
 
 ## Enum Types
 

--- a/website/versioned_docs/version-2.0/schema-schema.md
+++ b/website/versioned_docs/version-2.0/schema-schema.md
@@ -47,9 +47,20 @@ type Mutation {
 ## Scalar Types
 
 Scalar types are custom types that require a `directive` (which we'll learn about later) to serialize, deserialize and validate values.
+<br><br>
+Ligthouse includes a DateTime scalar type. This scalar type can be used to handle Carbon DateTime fields. 
+You can use it inside your schema like this:
 
 ```graphql
-scalar DateTime @scalar(class: "DateTimeScalar")
+scalar DateTime @scalar(class: "App\\GraphQL\\Scalars\\DateTimeScalar")
+
+type User {
+  id: ID!
+  name: String!
+  email: String!
+  created_at: DateTime!
+  updated_at: DateTime
+}
 ```
 
 ## Enum Types

--- a/website/versioned_docs/version-2.0/schema-schema.md
+++ b/website/versioned_docs/version-2.0/schema-schema.md
@@ -52,7 +52,7 @@ Ligthouse includes a DateTime scalar type. This scalar type can be used to handl
 You can use it inside your schema like this:
 
 ```graphql
-scalar DateTime @scalar(class: "App\\GraphQL\\Scalars\\DateTimeScalar")
+scalar DateTime @scalar(class: "App\\GraphQL\\Scalars\\DateTime")
 
 type User {
   id: ID!

--- a/website/versioned_sidebars/version-2.0-sidebars.json
+++ b/website/versioned_sidebars/version-2.0-sidebars.json
@@ -7,7 +7,7 @@
     ],
     "Schema": [
       "version-2.0-schema",
-      "version-2.0-schema-scalar-types"
+      "version-2.0-schema-scalars"
     ],
     "Directives": [
       "version-2.0-directives-args",

--- a/website/versioned_sidebars/version-2.0-sidebars.json
+++ b/website/versioned_sidebars/version-2.0-sidebars.json
@@ -6,7 +6,8 @@
       "version-2.0-configuration"
     ],
     "Schema": [
-      "version-2.0-schema"
+      "version-2.0-schema",
+      "version-2.0-schema-scalar-types"
     ],
     "Directives": [
       "version-2.0-directives-args",

--- a/website/versioned_sidebars/version-2.1-sidebars.json
+++ b/website/versioned_sidebars/version-2.1-sidebars.json
@@ -7,7 +7,8 @@
     ],
     "Schema": [
       "version-2.1-schema",
-      "version-2.1-schema-extending"
+      "version-2.1-schema-extending",
+      "version-2.1-schema-scalars"
     ],
     "Directives": [
       "version-2.1-directives-queries",


### PR DESCRIPTION
**Related Issue/PR from the main repo**

None

**Lighthouse Version**

2.0 (I think) and 2.1.

I ran into an issue with returning DateTime fields. It was a bit difficult to find in the docs how to use the included Scalar, so I decided to add an example.   
